### PR TITLE
Address homepage accessibility and style feedback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -63,9 +63,10 @@ select {
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
+    animation-duration: 0s !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    animation-play-state: paused !important;
+    transition-duration: 0s !important;
     scroll-behavior: auto !important;
   }
 }
@@ -78,7 +79,7 @@ select {
 :root {
   /* Text sizes */
   --base-text-size: clamp(1rem, 0.9565rem + 0.2174vw, 1.125rem);
-  --h1-text-size: clamp(1.6rem, 0.9565rem + 0.2174vw, 1.125rem);
+  --h1-text-size: clamp(1.125rem, 0.9565rem + 0.2174vw, 1.6rem);
   --mono-text-size: 1rem;
   --base-line-height: 1.5;
   /* Spacing */
@@ -101,13 +102,6 @@ select {
     --font-family: "Inter V", ui-sans-serif, system-ui, -system-ui, -apple-system,
       BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif,
       "Apple Color Emoji";
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 1, 71, 55;
-    --background-rgb: 243, 250, 247;
   }
 }
 
@@ -190,6 +184,10 @@ ol {
   padding-left: 1.5rem;
 }
 
+.wrap ul + p {
+  margin-top: 1.5rem;
+}
+
 blockquote {
   padding: 0 var(--space-s-m);
   font-variation-settings: "slnt"10;
@@ -222,13 +220,6 @@ div.highlight {
   margin: 0 auto;
 }
 
-.global-header {
-  position: fixed;
-  width: 100%;
-  top: 0;
-  left: 0;
-}
-
 .home-link {
   margin-bottom: 2rem;
 }
@@ -243,31 +234,6 @@ div.highlight {
 
 .metadata {
   color: rgba(var(--foreground-rgb), 0.5);
-}
-
-.footnotes {
-  margin-top: 2rem;
-  color: rgba(var(--foreground-rgb), 0.75);
-}
-
-.reversefootnote {
-  color: rgba(var(--foreground-rgb), 0.75);
-  text-decoration: none;
-}
-
-.tags {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.tag {
-  color: rgba(var(--foreground-rgb), 0.5);
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }
 
 /* Case study (same layout on all viewports) */
@@ -330,7 +296,7 @@ h2.split-title { margin: 2rem 0 .25rem; }
 .identity__title {
   margin: 0 0 2px;
   line-height: 1.1;
-  font-size: clamp(1.6rem, 3.5vw, 1.5rem);
+  font-size: clamp(1.25rem, 3.5vw, 1.6rem);
 }
 
 .identity__subtitle {

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <div class="identity">
             <img class="identity__avatar_primary" src="images/avatar-shaun.jpg" alt="Photo of Shaun Byrne" width="96" height="96" decoding="async" fetchpriority="high">
             <div class="identity__text">
-              <h1 class="identity__title">Shaun Byrne</h1>
+              <p class="identity__title">Shaun Byrne</p>
               <p class="identity__subtitle">Design &amp; Product</p>
             </div>
           </div>
@@ -77,15 +77,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <section>
         <h3>Now</h3>
         <ul>
-          <li>Head of Design & Product, <a target="_blank" href="https://black.ai/">black.ai</a></li>
+          <li>Head of Design & Product, <a target="_blank" rel="noopener noreferrer" href="https://black.ai/">black.ai</a></li>
         </ul>
         <h3>Previously</h3>
         <ul>
-          <li>Head of Product Design, <a target="_blank" href="https://www.zipline.io/">Zipline</a></li>
-          <li>Head of User Experience, <a target="_blank" href="https://www.opypro.com.au/">Openpay</a></li>
-          <li>Product Designer → Product Design Lead, <a target="_blank" href="https://www.redbubble.com/">Redbubble</a></li>
-          <li>Lead UX Designer, <a target="_blank" href="https://www.newscorpaustralia.com/">News Digital Media - Learning Seat</a></li>
-        </ul><br>
+          <li>Head of Product Design, <a target="_blank" rel="noopener noreferrer" href="https://www.zipline.io/">Zipline</a></li>
+          <li>Head of User Experience, <a target="_blank" rel="noopener noreferrer" href="https://www.opypro.com.au/">Openpay</a></li>
+          <li>Product Designer → Product Design Lead, <a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a></li>
+          <li>Lead UX Designer, <a target="_blank" rel="noopener noreferrer" href="https://www.newscorpaustralia.com/">News Digital Media - Learning Seat</a></li>
+        </ul>
         <p>I help design orgs mature — growing teams, partnering with leaders, and staying close to the work. See what people say about me on  <a href="https://www.linkedin.com/in/byrneshaun/details/recommendations/">LinkedIn</a>.</p>
       </section>
     </div>

--- a/work/index.html
+++ b/work/index.html
@@ -86,7 +86,7 @@
               <img src="images/work_black01.jpg" alt="Case D placeholder" loading="lazy">
           </div>
           <div class="case-split__body">
-            <h2 class="split-title"><a target="_blank" href="http://www.black.ai">black.ai</a> — Turning VisionAI R&D into Enterprise SaaS</h2>
+            <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="http://www.black.ai">black.ai</a> — Turning VisionAI R&D into Enterprise SaaS</h2>
             <p class="muted">Head of Product & Design • Leading 3 product teams</p>
             <p>I translated complex computer vision workflows into usable retail tools — from configuring camera zones and segmenting shopper journeys, to surfacing real-time alerts. Prioritised iterative improvements that moved setup and experimentation from engineers to CSMs and customers, letting them design and run store experiments directly.
             </p>
@@ -99,7 +99,7 @@
               <img src="images/work_op01.jpg" alt="Case D placeholder" loading="lazy">
           </div>
           <div class="case-split__body">
-            <h2 class="split-title"><a target="_blank" href="https://www.opypro.com.au/">Openpay</a> — Global App Launch</h2>
+            <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.opypro.com.au/">Openpay</a> — Global App Launch</h2>
             <p class="muted">Head of User Experience • Leading design org of ~8</p>
             <p>
               Openpay was scaling from Australia to the UK but had no design practice, outdated apps, and poor reviews. I set design goals, consolidated research, and built a new cross-functional team. Led design of new iOS and Android apps, introduced a design system, simplified onboarding, and addressed accessibility — balancing hands-on UX work with establishing design culture.
@@ -113,7 +113,7 @@
               <img src="images/work_rb01.jpg" alt="Case D placeholder" loading="lazy">
           </div>
           <div class="case-split__body">
-            <h2 class="split-title"><a target="_blank" href="https://www.redbubble.com/">Redbubble</a> — Smarter Search Suggestions</h2>
+            <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Smarter Search Suggestions</h2>
             <p class="muted">Product Design Lead • Leading design of a core space</p>
             <p>Search is the heart of Redbubble’s marketplace, but users often abandoned due to friction. I led discovery, prototyping, and design of autocomplete suggestions — reducing input effort and surfacing long-tail content. Balanced the details of interaction design with working alongside engineers and data science to make ML-powered search usable at scale.</p>
             <p><strong>Impact:</strong> +30% search engagement, fewer “zero result” pages, higher add-to-cart, and stronger customer confidence in finding “their thing.”</p>
@@ -127,7 +127,7 @@
             </a>
           </div>
           <div class="case-split__body">
-            <h2 class="split-title"><a target="_blank" href="https://www.redbubble.com/">Redbubble</a> — Confident Product Decisions</h2>
+            <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Confident Product Decisions</h2>
             <p class="muted">Product Design Lead • Leading design of a core space</p>
             <p>
               Product pages lacked trust: unclear shipping, poor product info, and weak social proof. I ran interviews, card sorts, and A/B tests to uncover the biggest levers, then designed solutions including shipping estimates, better product information, ML-powered recommendations, and reviews. Balanced detailed interface design with influencing product strategy for how new products would onboard.


### PR DESCRIPTION
## Summary
- convert the avatar lock-up heading into paragraph text and add rel attributes to external links to harden new-tab behavior
- remove the layout `<br>` and enforce spacing via CSS while correcting clamp ranges and reduced-motion handling
- drop unused legacy selectors and the misleading dark-mode hint to keep the live stylesheet lean

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eeeb78eef8832c81082e3c5c8b5e5b