### PR TITLE
Add fade-in animation for about and work page imagery

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -74,7 +74,7 @@
         </header>
         <!-- Content -->
         <section>
-          <img src="images/redbubble_dribble-meetup-hero.jpg" style="max-height:600px; margin: 1rem auto; margin-bottom: 3rem; border-radius: 0.75rem;">
+          <img src="images/redbubble_dribble-meetup-hero.jpg" data-fade-in style="max-height:600px; margin: 1rem auto; margin-bottom: 3rem; border-radius: 0.75rem;">
           <h1>About me</h1>
           <p>
             I’m at my best where design and product meet — turning messy problems into simple, scalable solutions. I love combining the patterns in data with the stories from users, because that’s where the real opportunities emerge.

--- a/about/index.html
+++ b/about/index.html
@@ -74,7 +74,9 @@
         </header>
         <!-- Content -->
         <section>
-          <img src="images/redbubble_dribble-meetup-hero.jpg" data-fade-in style="max-height:600px; margin: 1rem auto; margin-bottom: 3rem; border-radius: 0.75rem;">
+          <div class="about-hero" data-fade-container>
+            <img src="images/redbubble_dribble-meetup-hero.jpg" alt="Shaun speaking at a Redbubble and Dribbble meetup" width="1318" height="658" decoding="async" data-fade-in>
+          </div>
           <h1>About me</h1>
           <p>
             I’m at my best where design and product meet — turning messy problems into simple, scalable solutions. I love combining the patterns in data with the stories from users, because that’s where the real opportunities emerge.

--- a/css/styles.css
+++ b/css/styles.css
@@ -49,6 +49,19 @@ picture {
   display: block;
 }
 
+.about-hero {
+  margin: 1rem auto 3rem;
+  max-height: 600px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.about-hero img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
 body.js-enabled img[data-fade-in] {
   opacity: 0;
   transition: opacity 320ms ease-in-out;
@@ -56,6 +69,43 @@ body.js-enabled img[data-fade-in] {
 
 body.js-enabled img[data-fade-in].is-visible {
   opacity: 1;
+}
+
+body.js-enabled [data-fade-container] {
+  position: relative;
+}
+
+body.js-enabled [data-fade-container]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg,
+      rgba(var(--foreground-rgb), 0.07) 25%,
+      rgba(var(--foreground-rgb), 0.12) 37%,
+      rgba(var(--foreground-rgb), 0.07) 63%);
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: none;
+  transition: opacity 200ms ease, visibility 0s linear 200ms;
+}
+
+body.js-enabled [data-fade-container].is-loaded::before {
+  opacity: 0;
+  visibility: hidden;
+  animation-play-state: paused;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 /* Inherit fonts for inputs and buttons */
@@ -283,7 +333,9 @@ h2.split-title { margin: 2rem 0 .25rem; }
   padding-bottom: 2px;
 }
 
-.case-split__media img { transition: transform .45s ease; }
+.case-split__media img {
+  transition: transform .45s ease, opacity 320ms ease-in-out;
+}
 .case-split__media:hover img { transform: scale(1.03); }
 
 /* Avatar lock-up */

--- a/css/styles.css
+++ b/css/styles.css
@@ -334,9 +334,8 @@ h2.split-title { margin: 2rem 0 .25rem; }
 }
 
 .case-split__media img {
-  transition: transform .45s ease, opacity 320ms ease-in-out;
+  transition: opacity 320ms ease-in-out;
 }
-.case-split__media:hover img { transform: scale(1.03); }
 
 /* Avatar lock-up */
 .identity {

--- a/css/styles.css
+++ b/css/styles.css
@@ -49,6 +49,15 @@ picture {
   display: block;
 }
 
+body.js-enabled img[data-fade-in] {
+  opacity: 0;
+  transition: opacity 320ms ease-in-out;
+}
+
+body.js-enabled img[data-fade-in].is-visible {
+  opacity: 1;
+}
+
 /* Inherit fonts for inputs and buttons */
 input,
 button,

--- a/js/script.js
+++ b/js/script.js
@@ -51,22 +51,29 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!fadeImages.length) return;
 
   fadeImages.forEach((img) => {
-    const reveal = () => {
+    const container = img.closest('[data-fade-container]');
+    const markLoaded = () => {
       img.classList.add('is-visible');
+      if (container) {
+        container.classList.add('is-loaded');
+      }
     };
 
     if (img.complete && img.naturalWidth > 0) {
       // Already loaded (cached)
-      requestAnimationFrame(reveal);
+      requestAnimationFrame(markLoaded);
       return;
     }
 
     img.addEventListener('load', () => {
-      requestAnimationFrame(reveal);
+      requestAnimationFrame(markLoaded);
     }, { once: true });
 
     img.addEventListener('error', () => {
       img.classList.add('is-visible');
+      if (container) {
+        container.classList.add('is-loaded');
+      }
     }, { once: true });
   });
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,6 @@
 // Email copy: supports one or many .emailAction elements
 document.addEventListener('DOMContentLoaded', () => {
+  document.body?.classList.add('js-enabled');
   const els = document.querySelectorAll('.emailAction');
   if (!els.length) return;
 
@@ -42,5 +43,30 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.click();
       }
     });
+  });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const fadeImages = document.querySelectorAll('img[data-fade-in]');
+  if (!fadeImages.length) return;
+
+  fadeImages.forEach((img) => {
+    const reveal = () => {
+      img.classList.add('is-visible');
+    };
+
+    if (img.complete && img.naturalWidth > 0) {
+      // Already loaded (cached)
+      requestAnimationFrame(reveal);
+      return;
+    }
+
+    img.addEventListener('load', () => {
+      requestAnimationFrame(reveal);
+    }, { once: true });
+
+    img.addEventListener('error', () => {
+      img.classList.add('is-visible');
+    }, { once: true });
   });
 });

--- a/work/index.html
+++ b/work/index.html
@@ -83,7 +83,7 @@
         </section>
         <section class="case-split" aria-labelledby="split-title">
           <div class="case-split__media">
-              <img src="images/work_black01.jpg" alt="Case D placeholder" loading="lazy">
+              <img src="images/work_black01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="http://www.black.ai">black.ai</a> — Turning VisionAI R&D into Enterprise SaaS</h2>
@@ -96,7 +96,7 @@
         </section>
         <section class="case-split" aria-labelledby="split-title">
           <div class="case-split__media">
-              <img src="images/work_op01.jpg" alt="Case D placeholder" loading="lazy">
+              <img src="images/work_op01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.opypro.com.au/">Openpay</a> — Global App Launch</h2>
@@ -110,7 +110,7 @@
         </section>
         <section class="case-split" aria-labelledby="split-title">
           <div class="case-split__media">
-              <img src="images/work_rb01.jpg" alt="Case D placeholder" loading="lazy">
+              <img src="images/work_rb01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Smarter Search Suggestions</h2>
@@ -123,7 +123,7 @@
         <section class="case-split" aria-labelledby="split-title">
           <div class="case-split__media">
             <a href="#">
-              <img src="images/work_rb02.jpg" alt="Case D placeholder" loading="lazy">
+              <img src="images/work_rb02.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
             </a>
           </div>
           <div class="case-split__body">

--- a/work/index.html
+++ b/work/index.html
@@ -82,8 +82,8 @@
           </p>
         </section>
         <section class="case-split" aria-labelledby="split-title">
-          <div class="case-split__media">
-              <img src="images/work_black01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
+          <div class="case-split__media" data-fade-container>
+              <img src="images/work_black01.jpg" alt="Case D placeholder" loading="lazy" decoding="async" width="1920" height="1920" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="http://www.black.ai">black.ai</a> — Turning VisionAI R&D into Enterprise SaaS</h2>
@@ -95,8 +95,8 @@
           </div>
         </section>
         <section class="case-split" aria-labelledby="split-title">
-          <div class="case-split__media">
-              <img src="images/work_op01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
+          <div class="case-split__media" data-fade-container>
+              <img src="images/work_op01.jpg" alt="Case D placeholder" loading="lazy" decoding="async" width="800" height="800" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.opypro.com.au/">Openpay</a> — Global App Launch</h2>
@@ -109,8 +109,8 @@
           </div>
         </section>
         <section class="case-split" aria-labelledby="split-title">
-          <div class="case-split__media">
-              <img src="images/work_rb01.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
+          <div class="case-split__media" data-fade-container>
+              <img src="images/work_rb01.jpg" alt="Case D placeholder" loading="lazy" decoding="async" width="800" height="800" data-fade-in>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Smarter Search Suggestions</h2>
@@ -121,9 +121,9 @@
           </div>
         </section>
         <section class="case-split" aria-labelledby="split-title">
-          <div class="case-split__media">
+          <div class="case-split__media" data-fade-container>
             <a href="#">
-              <img src="images/work_rb02.jpg" alt="Case D placeholder" loading="lazy" data-fade-in>
+              <img src="images/work_rb02.jpg" alt="Case D placeholder" loading="lazy" decoding="async" width="800" height="800" data-fade-in>
             </a>
           </div>
           <div class="case-split__body">


### PR DESCRIPTION
## Summary
- add a reusable fade-in treatment for images marked with `data-fade-in`
- mark about and work page imagery to use the new animation for a smoother reveal
- ensure cached or failed images still become visible without flicker

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ef10bdda98832c8fd4bb9d6cdf2ef7