### PR TITLE
Add video-led Redbubble search filtering case study

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -321,7 +321,8 @@ div.highlight {
   width: 100%;
   height: auto;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
+  object-fit: contain;
+  background-color: #000;
   border-radius: 8px;
   display: block;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -312,6 +312,7 @@ div.highlight {
   border-radius: 16px;
   display: flex;
   justify-content: center;
+  width: 100%;
 }
 
 body.js-enabled .case-split__media--video::before {
@@ -333,7 +334,7 @@ body.js-enabled .case-split__media--video::before {
   height: auto;
   aspect-ratio: 1 / 1;
   object-fit: contain;
-  background-color: #000;
+  background-color: transparent;
   border-radius: 8px;
   display: block;
 }
@@ -345,7 +346,7 @@ body.js-enabled .case-split__media--video::before {
 }
 
 .case-split__video-frame {
-  width: min(100%, 520px);
+  width: 100%;
   aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -307,6 +307,17 @@ div.highlight {
   border-radius: 8px;
 }
 
+.case-split__media--video {
+  overflow: visible;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+body.js-enabled .case-split__media--video::before {
+  content: none;
+}
+
 /* Keep a consistent crop; remove if you want natural height */
 .case-split__media img {
   width: 100%;
@@ -325,6 +336,26 @@ div.highlight {
   background-color: #000;
   border-radius: 8px;
   display: block;
+}
+
+.case-split__media--video video {
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: 12px;
+}
+
+.case-split__video-frame {
+  width: min(100%, 520px);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 1rem + 2vw, 2.5rem);
+  background: #f6d5e0;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 6px 12px -2px rgba(50, 50, 93, 0.25),
+    0 3px 7px -3px rgba(0, 0, 0, 0.3);
 }
 
 h2.split-title { margin: 2rem 0 .25rem; }

--- a/css/styles.css
+++ b/css/styles.css
@@ -317,6 +317,15 @@ div.highlight {
   display: block;
 }
 
+.case-split__media video {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 8px;
+  display: block;
+}
+
 h2.split-title { margin: 2rem 0 .25rem; }
 
 .muted {

--- a/work/index.html
+++ b/work/index.html
@@ -136,6 +136,21 @@
             <p><a class="cta" href="#footer">Contact me</a> for more detail.</p>
           </div>
         </section>
+        <section class="case-split" aria-labelledby="split-title">
+          <div class="case-split__media" data-fade-container>
+            <video autoplay muted loop playsinline data-fade-in>
+              <source src="images/work_rb03.mp4" type="video/mp4">
+              Motion preview of Redbubble search filter interaction design.
+            </video>
+          </div>
+          <div class="case-split__body">
+            <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Future-Proofing Search Filtering</h2>
+            <p class="muted">Product Design Lead • Advancing search & discovery</p>
+            <p>Redbubble’s filters varied wildly across product types, leaving people without the control they needed to find “their thing.” I synthesised qualitative research and behavioural data to uncover the most critical filtering jobs, then prototyped and tested a responsive model that could flex across devices and product growth.</p>
+            <p><strong>Impact:</strong> Delivered a scalable pattern adopted across marketplace surfaces, empowering shoppers with faster, more confident discovery while unlocking future filter expansion.</p>
+            <p><a class="cta" href="#footer">Contact me</a> for more detail.</p>
+          </div>
+        </section>
       </article>
     </div>
   </main>

--- a/work/index.html
+++ b/work/index.html
@@ -137,11 +137,13 @@
           </div>
         </section>
         <section class="case-split" aria-labelledby="split-title">
-          <div class="case-split__media" data-fade-container>
-            <video autoplay muted loop playsinline data-fade-in>
-              <source src="images/work_rb03.mp4" type="video/mp4">
-              Motion preview of Redbubble search filter interaction design.
-            </video>
+          <div class="case-split__media case-split__media--video" data-fade-container>
+            <div class="case-split__video-frame">
+              <video autoplay muted loop playsinline data-fade-in>
+                <source src="images/work_rb03.mp4" type="video/mp4">
+                Motion preview of Redbubble search filter interaction design.
+              </video>
+            </div>
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Future-Proofing Search Filtering</h2>


### PR DESCRIPTION
## Summary
- add the Redbubble search filtering case study from the 2025 portfolio to the current work page
- support video previews for case studies so the Redbubble piece uses a looping motion teaser

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f18593a758832cb6b4fbb0321b48e5