### PR TITLE
Update Future-Proofing case study title and styling

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -94,7 +94,7 @@
   <footer>
     <p class="home-link"><a href="../">Back to Home</a></p>
     <p>
-      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
+      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <a href="https://docs.google.com/document/d/1Iy7VWN8_VQTqDlexdUr17fWW38dDUMTtkl8M9pjSNr0/edit?usp=sharing">Resume</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
         <span class="emailAction__labels" aria-live="polite">
           <span class="label label--default" aria-hidden="true">Email</span>
           <span class="label label--copied" aria-hidden="true">copied!</span>

--- a/css/styles.css
+++ b/css/styles.css
@@ -355,8 +355,6 @@ body.js-enabled .case-split__media--video::before {
   background: #f6d5e0;
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 6px 12px -2px rgba(50, 50, 93, 0.25),
-    0 3px 7px -3px rgba(0, 0, 0, 0.3);
 }
 
 h2.split-title { margin: 2rem 0 .25rem; }

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </main>
   <footer>
     <p>
-      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
+      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <a href="https://docs.google.com/document/d/1Iy7VWN8_VQTqDlexdUr17fWW38dDUMTtkl8M9pjSNr0/edit?usp=sharing">Resume</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
         <span class="emailAction__labels" aria-live="polite">
           <span class="label label--default" aria-hidden="true">Email</span>
           <span class="label label--copied" aria-hidden="true">copied!</span>

--- a/work/index.html
+++ b/work/index.html
@@ -147,7 +147,7 @@
           </div>
           <div class="case-split__body">
             <h2 class="split-title"><a target="_blank" rel="noopener noreferrer" href="https://www.redbubble.com/">Redbubble</a> — Future-Proofing Search Filtering</h2>
-            <p class="muted">Product Design Lead • Advancing search & discovery</p>
+            <p class="muted">Product Design Lead • Leading design of a core space</p>
             <p>Redbubble’s filters varied wildly across product types, leaving people without the control they needed to find “their thing.” I synthesised qualitative research and behavioural data to uncover the most critical filtering jobs, then prototyped and tested a responsive model that could flex across devices and product growth.</p>
             <p><strong>Impact:</strong> Delivered a scalable pattern adopted across marketplace surfaces, empowering shoppers with faster, more confident discovery while unlocking future filter expansion.</p>
             <p><a class="cta" href="#footer">Contact me</a> for more detail.</p>

--- a/work/index.html
+++ b/work/index.html
@@ -159,7 +159,7 @@
   <footer id="footer">
     <p class="home-link"><a href="../">Back to Home</a></p>
     <p>
-      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
+      <a href="https://x.com/byrnecore">Twitter/X</a> | <a href="https://www.linkedin.com/in/byrneshaun/">LinkedIn</a> | <a href="https://dribbble.com/byrnecore">Dribbble</a> | <a href="https://www.instagram.com/byrnecore">Instagram</a> | <a href="https://docs.google.com/document/d/1Iy7VWN8_VQTqDlexdUr17fWW38dDUMTtkl8M9pjSNr0/edit?usp=sharing">Resume</a> | <button class="emailAction" data-email="byrnecore@gmail.com">
         <span class="emailAction__labels" aria-live="polite">
           <span class="label label--default" aria-hidden="true">Email</span>
           <span class="label label--copied" aria-hidden="true">copied!</span>


### PR DESCRIPTION
## Summary
- align the Future-Proofing Search Filtering case study title with the updated product design lead phrasing
- remove the drop shadow from the Future-Proofing preview frame to match other case study previews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f19a4ebbc0832c9269c19c7897193b